### PR TITLE
Fix: Update base image to cirruslabs/flutter:stable to resolve Dart SDK 3.8.1+ compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,45 +1,80 @@
-FROM fischerscode/flutter-sudo:stable
-#USER root
-# Set working directory
-WORKDIR /app
+# InvenTree APK Builder
+# Builds the InvenTree Android app from source using the latest stable Flutter SDK.
+# Based on ghcr.io/cirruslabs/flutter:stable which tracks the latest Flutter/Dart stable release.
 
-# Install dependencies
-RUN sudo apt-get update && sudo apt-get install -y git python3 python3-pip unzip wget python3-venv android-sdk ninja-build
-
-# Create a virtual environment for Python dependencies
-RUN sudo python3 -m venv /env
-RUN sudo /env/bin/pip install --upgrade pip
-RUN sudo /env/bin/pip install invoke
-
-# Clean the app directory and clone the Git repository
-RUN rm -rf /app/* \
-    && git clone https://github.com/inventree/inventree-app.git /app
-RUN git config --global --add safe.directory /home/mobiledevops/.flutter-sdk
-# Create a symlink for Python
-RUN sudo ln -s /usr/bin/python3 /usr/bin/python
-
-# Run localization before pub get using virtual environment's invoke
-RUN /env/bin/invoke translate
-
-# Install dependencies using flutter pub get with global flutter
-RUN flutter pub get
+FROM ghcr.io/cirruslabs/flutter:stable
 
 USER root
 
-# Run Android-specific setup
-RUN git config --global --add safe.directory /home/flutter/flutter-sdk
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    git \
+    python3 \
+    python3-pip \
+    python3-venv \
+    unzip \
+    wget \
+    ninja-build \
+    openjdk-17-jdk \
+    && rm -rf /var/lib/apt/lists/*
 
-RUN apt-get -y install openjdk-17-jdk 
+# Set JAVA_HOME
+ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
 
-RUN echo "storePassword=Secret123\nkeyPassword=Secret123\nkeyAlias=key\nstoreFile=/tmp/keys.jks" > /app/android/key.properties
+WORKDIR /app
 
-RUN echo -ne "\n24333f8a63b6825ea9c5514f83c2829b004d1fee" > /usr/lib/android-sdk/licenses/android-sdk-license && \
-	keytool -genkeypair -v -keystore /tmp/keys.jks -keyalg RSA -keysize 2048 -validity 10000 -alias key -storepass Secret123 -keypass Secret123 -dname "CN=Dummy, OU=Dummy, O=Dummy, L=Dummy, ST=Dummy, C=US" 
-RUN /env/bin/invoke android
+# Create Python venv and install invoke
+RUN python3 -m venv /env \
+    && /env/bin/pip install --upgrade pip --quiet \
+    && /env/bin/pip install invoke --quiet
+
+# Create python symlink required by invoke tasks
+RUN ln -s /usr/bin/python3 /usr/bin/python
+
+# Clone InvenTree app source
+RUN echo "--- Cloning InvenTree app source ---" \
+    && git clone https://github.com/inventree/inventree-app.git /app
+
+# Accept Android SDK licenses
+RUN echo "--- Accepting Android SDK licenses ---" \
+    && yes | flutter doctor --android-licenses > /dev/null 2>&1 || true
+
+# Run flutter doctor to pre-cache SDK components
+RUN echo "--- Running flutter doctor ---" \
+    && flutter doctor 2>&1 | grep -v "^$" || true
+
+# Generate localization files
+RUN echo "--- Generating localization files ---" \
+    && cd /app && /env/bin/invoke translate 2>&1 | grep -v "untranslated"
+
+# Install Flutter dependencies
+RUN echo "--- Installing Flutter dependencies ---" \
+    && cd /app && flutter pub get 2>&1 | tail -5
+
+# Generate keystore for APK signing
+RUN echo "--- Generating signing keystore ---" \
+    && printf 'storePassword=Secret123\nkeyPassword=Secret123\nkeyAlias=key\nstoreFile=/tmp/keys.jks' > /app/android/key.properties \
+    && keytool -genkeypair -v \
+        -keystore /tmp/keys.jks \
+        -keyalg RSA \
+        -keysize 2048 \
+        -validity 10000 \
+        -alias key \
+        -storepass Secret123 \
+        -keypass Secret123 \
+        -dname "CN=Dummy, OU=Dummy, O=Dummy, L=Dummy, ST=Dummy, C=US" \
+        > /dev/null 2>&1
+
+# Accept SDK license
+RUN mkdir -p /root/Android/Sdk/licenses \
+    && echo "24333f8a63b6825ea9c5514f83c2829b004d1fee" > /root/Android/Sdk/licenses/android-sdk-license
 
 RUN mkdir -p /output
-
 VOLUME ["/output"]
 
-# Set the default command to build the APK
-CMD flutter build apk && mkdir -p /output && cp build/app/outputs/flutter-apk/app-release.apk /output/app.apk
+CMD echo "--- Starting InvenTree APK build ---" \
+    && cd /app \
+    && flutter build apk --release 2>&1 | grep -E "(error|warning|Built|Running|Gradle|FAILED|Exception)" \
+    && cp build/app/outputs/flutter-apk/app-release.apk /output/app.apk \
+    && echo "--- Build complete. APK saved to /output/app.apk ---"

--- a/README.md
+++ b/README.md
@@ -1,49 +1,62 @@
-InvenTree mobile app: APK builder (Android)
-==================================
+# InvenTree APK Builder (Android)
 
-This repository provides a Dockerfile to automate the build process for the InvenTree Android app, resulting in an APK file placed in the output directory.
+Builds the InvenTree Android app from source using Docker, producing an APK file in the output directory.
 
-In the releases section, one can download pre-built APK files, maintained on a best effort basis.
+The official InvenTree mobile app requires a paid download. This tool builds it for free from the open-source MIT-licensed source code at https://github.com/inventree/inventree-app.
 
-Requirements
-------------
+## Requirements
 
-*   Docker installed
-    
+- Docker Desktop (Windows/Mac) or Docker Engine (Linux)
+- ~10 GB free disk space (Flutter SDK + Android NDK + build cache)
 
-Usage
------
+## Usage
 
-1.  mkdir -p ./output
-    
-2.  docker build -t inventree-dockerbuild .
-    
-3.  docker run -v $(pwd)/output:/output -ti --rm inventree-dockerbuild
-    
+**1. Clone this repository**
 
-Output
-------
+    git clone https://github.com/your-repo/inventree-apk-builder
+    cd inventree-apk-builder
 
-*   The generated APK file will be available in the output subdirectory.
-    
+**2. Build the Docker image**
 
-Notes
------
+    docker build -t inventree-apk-builder .
 
-*   The Dockerfile clones the InvenTree Android app source and compiles it.   
-    
-*   The output directory is mapped to extract the generated APK from the container.
-    
+**3. Create the output directory and run the build**
 
-Troubleshooting
----------------
+    mkdir output
+    docker run --rm -v ${PWD}/output:/output inventree-apk-builder
 
-*   Ensure adequate disk space and correct dependency versions.
-    
-*   Run docker logs for build errors.
-    
+On first run, Gradle will download the Android SDK, NDK, and CMake. This takes 15-30 minutes depending on your connection. Subsequent runs use Docker layer cache and are much faster.
 
-License
--------
+**4. Install the APK**
+
+The APK will be at `output/app.apk`. Transfer it to your Android device and install it. You may need to enable "Install from unknown sources" in your device settings.
+
+## Connecting to InvenTree
+
+After installing, open the app and add your server:
+
+- Server URL: http://YOUR_SERVER_IP:PORT
+- Username and password: your InvenTree admin credentials
+- Your phone must be on the same network as your InvenTree server for local installs
+
+## Output
+
+- `output/app.apk` - signed release APK ready to install on Android
+
+## Notes
+
+- The Dockerfile clones the latest stable InvenTree app source on every image build. To pin to a specific version, edit the git clone line in the Dockerfile to use a specific tag.
+- The APK is signed with a self-generated dummy keystore. It is not suitable for Play Store publishing.
+- iOS is not supported. Apple requires a paid developer account to sideload apps.
+
+## Troubleshooting
+
+- **Out of disk space**: The build requires ~10 GB. Free up space or increase Docker Desktop's disk image size in Settings > Resources.
+- **Build fails with Gradle error**: Run `docker build --no-cache` to force a fresh clone of the latest source.
+- **App cannot connect to server**: Ensure your phone and server are on the same network. Use the IP address, not a hostname.
+
+## License
 
 Licensed under the MIT License. See the LICENSE file for more information.
+
+The InvenTree app source code is also MIT licensed: https://github.com/inventree/inventree-app

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The official InvenTree mobile app requires a paid download. This tool builds it 
 
 **1. Clone this repository**
 
-    git clone https://github.com/your-repo/inventree-apk-builder
+    git clone https://github.com/arshmalkana/inventree-apk-builder
     cd inventree-apk-builder
 
 **2. Build the Docker image**


### PR DESCRIPTION
## Problem

The current Dockerfile uses fischerscode/flutter-sudo:stable as the base image, 
which ships with Flutter 3.5.3 / Dart SDK 3.5.3. The InvenTree app now requires 
Dart SDK ^3.8.1, causing the build to fail at `flutter pub get` with:

    Because inventree requires SDK version ^3.8.1, version solving failed.

This makes the tool completely broken against the current InvenTree app source.

## Changes

- Replaced base image with ghcr.io/cirruslabs/flutter:stable, which always 
  tracks the latest stable Flutter/Dart release and includes the Android SDK
- Removed the broken android-sdk apt package (now provided by the base image)
- Added openjdk-17-jdk with proper JAVA_HOME configuration
- Fixed key.properties generation (printf instead of echo to handle \n correctly)
- Added build step logging with clear section headers for easier debugging
- Suppressed noisy output (pip, licenses, untranslated strings) while keeping 
  errors and build milestones visible
- Updated README to reflect new usage, disk space requirements, and added 
  troubleshooting section

## Tested

Built and verified successfully on Docker Desktop for Windows, producing a 
working 89.5MB app-release.apk from the latest InvenTree app source.